### PR TITLE
Upload toolboxes to manually created releases

### DIFF
--- a/.github/workflows/release-matlab-toolbox.yml
+++ b/.github/workflows/release-matlab-toolbox.yml
@@ -1,43 +1,40 @@
 name: Build & Release MATLAB Toolbox
 
 on:
-  push:
-    tags:
-      - "v1.0.2
-  workflow_dispatch:
+  release:
+    types: [published]
 
-jobs:
+jobs:  
   release-toolbox:
+    if: github.repository == 'TopoToolbox/ttminvoellmy'
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write   # required to create GitHub Releases
-
+      contents: write   # required to update release      
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Set up MATLAB
-        uses: mathworks/setup-matlab@v2
-
+        uses: matlab-actions/setup-matlab@v2
+        with:
+          release: r2025a
+          cache: true
+          
       - name: Build toolbox
-        run: |
-          matlab -batch "try, packageToolbox, catch e, disp(getReport(e,'extended')), exit(1), end, exit(0)"
-
-      - name: Find toolbox file
-        id: find_toolbox
-        run: |
-          FILE=$(ls release/*.mltbx | head -n 1)
-          echo "toolbox_file=$FILE" >> $GITHUB_OUTPUT
+        uses: matlab-actions/run-build@v2
+        with:
+          tasks: package
 
       - name: Upload toolbox artifact
         uses: actions/upload-artifact@v4
         with:
-          name: matlab-toolbox
-          path: ${{ steps.find_toolbox.outputs.toolbox_file }}
+          name: toolbox
+          path: release/ttminvoellmy.mltbx
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ${{ steps.find_toolbox.outputs.toolbox_file }}
-          generate_release_notes: true
+      - name: Upload toolbox assets
+        shell: bash
+        run: gh release upload --repo $GITHUB_REPOSITORY $TAG release/ttminvoellmy.mltbx
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This is one possible way to do releases that should work for the File Exchange -- though I don't remember exactly what the requirements are for the File Exchange, so you might need to make some modifications.

The basic release process is:

1. Publish a new release manually on GitHub. Create a new tag with the appropriate version number on the new release form.
2. This action will package the toolbox and upload it to the recently created release

This is more or less what we do in pytopotoolbox at the moment.

You still have to create the release manually this way. There is a way to create a release when you push an appropriate tag to the repository, but that still requires some manual intervention to create the tag, and I think the workflow is a little nicer to make the release when you are ready on GitHub. If you'd rather make releases on tag pushes, I can update this PR.