### PR TITLE
Update reusable workflows to run on Node 24

### DIFF
--- a/.github/workflows/release-matlab-toolbox.yml
+++ b/.github/workflows/release-matlab-toolbox.yml
@@ -13,7 +13,7 @@ jobs:
       contents: write   # required to update release      
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
@@ -27,7 +27,7 @@ jobs:
           tasks: package
 
       - name: Upload toolbox artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: toolbox
           path: release/ttminvoellmy.mltbx


### PR DESCRIPTION
actions/checkout and actions/upload-artifact are upgraded to v6.0.2 and v7.0.0, respectively. They are pinned to the SHA of the respective commit.

The matlab-actions must still be updated for Node 24.